### PR TITLE
Probabilistic Sampling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,7 @@ const int GROWTH_FACTOR = 20;                   // growth factor (euclidean dist
 const float TOLERANCE = 40;                     // euclidean distance tolerance to end position
 const int OBSTACLE_DECETION_SEGMENTS = 15;      // number of segments between new node and closest node to check for collision
 
-const float RANDOM_SAMPLE_PROBABILITY = 0.6;    // probability that each sample will be random rather than sampling the goal position
+const float RANDOM_SAMPLE_PROBABILITY = 0.85;    // probability that each sample will be random rather than sampling the goal position
 
 int main(){
 

--- a/main.cpp
+++ b/main.cpp
@@ -17,11 +17,11 @@ const int HEIGHT = 1000;
 
 vector<int> STATE_SPACE = {WIDTH, HEIGHT};      // render window state space, contains obstacles, start, and end position
 
-const int GROWTH_FACTOR = 20;                  // growth factor (euclidean distance) of new nodes being added to tree
+const int GROWTH_FACTOR = 20;                   // growth factor (euclidean distance) of new nodes being added to tree
 const float TOLERANCE = 40;                     // euclidean distance tolerance to end position
 const int OBSTACLE_DECETION_SEGMENTS = 15;      // number of segments between new node and closest node to check for collision
 
-const float BIAS_TOWARDS_GOAL = 0.6;
+const float RANDOM_SAMPLE_PROBABILITY = 0.6;    // probability that each sample will be random rather than sampling the goal position
 
 int main(){
 
@@ -39,7 +39,7 @@ int main(){
   vector<float> start_pos = {-100.0, -100.0};
   vector<float> end_pos = {-100.0, -100.0};
 
-  RRT rrt(renderWindow, GROWTH_FACTOR, start_pos, end_pos, TOLERANCE, OBSTACLE_DECETION_SEGMENTS, BIAS_TOWARDS_GOAL);
+  RRT rrt(renderWindow, GROWTH_FACTOR, start_pos, end_pos, TOLERANCE, OBSTACLE_DECETION_SEGMENTS, RANDOM_SAMPLE_PROBABILITY);
 
   Font font;
   FileInputStream fontIn;

--- a/rrt.cpp
+++ b/rrt.cpp
@@ -8,7 +8,7 @@
 #include <ctime>
 
 
-RRT::RRT (sf::RenderWindow& stateSpace, float growthFactor, std::vector<float> start, std::vector<float> end, float tolerance, int obstacle_detection_segments, float bias_towards_goal)
+RRT::RRT (sf::RenderWindow& stateSpace, float growthFactor, std::vector<float> start, std::vector<float> end, float tolerance, int obstacle_detection_segments, float random_sample_probability)
   : _stateSpace(stateSpace) {
   
   std::vector<sf::RectangleShape> _obstacles = {};
@@ -19,7 +19,7 @@ RRT::RRT (sf::RenderWindow& stateSpace, float growthFactor, std::vector<float> s
   _startPosition = start;
   _endPosition = end;
 
-  _bias = bias_towards_goal;
+  _random_sample_probability = random_sample_probability;
 
   _mt = std::mt19937(time(nullptr));
 

--- a/rrt.cpp
+++ b/rrt.cpp
@@ -19,7 +19,11 @@ RRT::RRT (sf::RenderWindow& stateSpace, float growthFactor, std::vector<float> s
   _startPosition = start;
   _endPosition = end;
 
-  _random_sample_probability = random_sample_probability;
+  if (random_sample_probability > 1.0 || random_sample_probability < 0.0) {
+    _random_sample_probability = 1.0;
+  } else {
+    _random_sample_probability = random_sample_probability;
+  }
 
   _mt = std::mt19937(time(nullptr));
 
@@ -78,10 +82,22 @@ float RRT::getEuclideanDistance(std::vector<float> node1Position, std::vector<fl
 
 Node RRT::sampleStateSpace(){
   // generate new point in state space
-  std::uniform_real_distribution<float> x_dist(0, _stateSpace.getSize().x);
-  std::uniform_real_distribution<float> y_dist(0,  _stateSpace.getSize().y);
+  float new_x, new_y;
 
-  std::vector<float> newPoint = {x_dist(_mt), y_dist(_mt)};
+  std::uniform_real_distribution<float> random_sample_dist(0, 1.0);
+  if (random_sample_dist(_mt) < _random_sample_probability) {
+    std::uniform_real_distribution<float> x_dist(0, _stateSpace.getSize().x);
+    std::uniform_real_distribution<float> y_dist(0,  _stateSpace.getSize().y);
+
+    new_x = x_dist(_mt);
+    new_y = y_dist(_mt);
+  } else {
+    new_x = _endPosition[0];
+    new_y = _endPosition[1];
+  }
+
+
+  std::vector<float> newPoint = {new_x, new_y};
 
   std::set<Node*> children;
   Node newNode = Node(newPoint, nullptr, children);

--- a/rrt.h
+++ b/rrt.h
@@ -43,7 +43,7 @@ class RRT{
 
     bool _searchStarted = false;
     bool _goalReached = false;
-    float _bias;
+    float _random_sample_probability;
 
     // SFML OBJECTS
     sf::CircleShape _point;


### PR DESCRIPTION
Introduces a probability [0.0, 1.0] of randomly sampling the state space.  For each iteration, if random float in range [0,1.0] is less than random_sample_probability, sample will be taken randomly from state space. Else, new node will be directly sampled as goal node position.  This can reduce iterations to reach goal node at the cost of increasing vulnerability to getting stuck in local minima. 